### PR TITLE
Force using directory 'Program Files' without '(x86)' suffix

### DIFF
--- a/src/main/groovy/org/m2ci/msp/gradle/tasks/findbinary/FindBinaryWindows.groovy
+++ b/src/main/groovy/org/m2ci/msp/gradle/tasks/findbinary/FindBinaryWindows.groovy
@@ -12,8 +12,13 @@ class FindBinaryWindows extends FindBinary {
     // activate recursive search
     super.recursive = true
 
-    // add program files paths
-    def programFiles = System.getenv('ProgramFiles')
+    // add program files paths (look in both Program Files and Program Files (x86))
+
+    // force using the Program Files directory with no suffix, as 
+    // "Program  Files (x86)" is returned if using 32 bit JVM
+    def programFiles = System.getenv('ProgramFiles').replace(" (x86)", "")
+
+    // explicitly ask for x86
     def programFiles86 = System.getenv('ProgramFiles(x86)')
 
     if( programFiles != null ) {


### PR DESCRIPTION
by using 'replace' to catch whether the x86 directory is returned but not intended. This follows an issue on a Win7 computer where the executable could not be found when there was both 'Program Files' and 'Program Files (x86)' directories, but the executable was in 'Program Files'.
The issue appears to be from the use of differing 32/64 bit versions of software and JDK: See [a discussion of why the wrong directory may be output from System.getenv('ProgramFiles')](http://stackoverflow.com/questions/27312134/system-getenvprogramfiles-returns-c-program-files-x86) and [one suggested solution](http://stackoverflow.com/a/29091276)  implemented here.
